### PR TITLE
fix dates, make RSS validate, add Atom, copyright

### DIFF
--- a/app/utils/blog-rss-feed.server.ts
+++ b/app/utils/blog-rss-feed.server.ts
@@ -8,12 +8,14 @@ async function getRssFeedXml(request: Request) {
   const blogUrl = `${getDomainUrl(request)}/blog`
 
   return `
-    <rss xmlns:blogChannel="${blogUrl}" version="2.0">
+    <rss xmlns:blogChannel="http://backend.userland.com/blogChannelModule" version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
       <channel>
         <title>Alexandru Bereghici Blog</title>
         <link>${blogUrl}</link>
         <description>Alexandru Bereghici Blog</description>
+        <copyright>All rights reserved copyright Alexandru Bereghici 2022</copyright>
         <language>en-us</language>
+        <atom:link href="${blogUrl}/rss.xml" rel="self" type="application/rss+xml" />
         <ttl>40</ttl>
         ${posts
           .map(post =>
@@ -21,17 +23,7 @@ async function getRssFeedXml(request: Request) {
             <item>
               <title>${cdata(post.frontmatter.title)}</title>
               <description>${cdata(post.frontmatter.description)}</description>
-              <pubDate>${dateFns.format(
-                dateFns.add(
-                  post.frontmatter.date
-                    ? post.frontmatter.date instanceof Date
-                      ? post.frontmatter.date
-                      : dateFns.parseISO(post.frontmatter.date)
-                    : Date.now(),
-                  {minutes: new Date().getTimezoneOffset()},
-                ),
-                'yyyy-MM-ii',
-              )}</pubDate>
+              <pubDate>${new Date(post.date).toUTCString()}</pubDate>
               <link>${blogUrl}/${post.slug}</link>
               <guid>${blogUrl}/${post.slug}</guid>
             </item>


### PR DESCRIPTION
1. Currently, RSS is [invalid](https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2Fbereghici.dev%2Fblog%2Frss.xml) and all the dates are incorrect. For example, article  "Patch an NPM dependency with yarn" on RSS is shown as May 26th but RSS has it May 4th. Plus, format is incorrect, it should be not ISO but `.toUTCString()`.
2. Copyright needs to be added.
3. `xmlns:blogChannel` namespace URL is not website's URL but spec's URL.
4. Adds support for Atom too.

PS. Thanks for creating `remix-themes`.